### PR TITLE
Update admin.py

### DIFF
--- a/singleton_models/admin.py
+++ b/singleton_models/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.utils.translation import ugettext as _
 from django.utils.encoding import force_unicode
 from django.http import HttpResponseRedirect
-from django.utils.functional import update_wrapper
+from functools import update_wrapper
 
 
 class SingletonModelAdmin(admin.ModelAdmin):


### PR DESCRIPTION
Newer versions of Django no-longer include `update_wrapper`, as it's expected to be provided in the language's standard library.

Here's the error I was getting as of now:

```
  File "/usr/lib/python2.7/site-packages/singleton_models/admin.py", line 5, in <module>
    from django.utils.functional import update_wrapper
ImportError: cannot import name update_wrapper
```

My environment is: Django 1.6.2 final, and Python 2.7.6
