### PR TITLE
Update admin.py compatibility with Django 1.6

### DIFF
--- a/singleton_models/admin.py
+++ b/singleton_models/admin.py
@@ -18,7 +18,10 @@ class SingletonModelAdmin(admin.ModelAdmin):
         return False
 
     def get_urls(self):
-        from django.conf.urls import patterns, url
+        try:
+            from django.conf.urls.defaults import patterns, url
+        except ImportError:
+            from django.conf.urls import patterns, url
 
         def wrap(view):
             def wrapper(*args, **kwargs):

--- a/singleton_models/admin.py
+++ b/singleton_models/admin.py
@@ -18,7 +18,7 @@ class SingletonModelAdmin(admin.ModelAdmin):
         return False
 
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url
+        from django.conf.urls import patterns, url
 
         def wrap(view):
             def wrapper(*args, **kwargs):


### PR DESCRIPTION
removed defaults parameter in get_urls method that crashes the SingletonModelAdmin Class
